### PR TITLE
Draft: Fix ingress usage. Add possibility to create list of services

### DIFF
--- a/charts/app/templates/ingress.yaml
+++ b/charts/app/templates/ingress.yaml
@@ -19,6 +19,7 @@ metadata:
 {{- end }}
 {{- end }}
 spec:
+  ingressClassName: nginx
   rules:
 {{- if .Values.ingress.fqdn }}
   - host: {{ .Values.ingress.fqdn }}

--- a/charts/app/templates/ingress.yaml
+++ b/charts/app/templates/ingress.yaml
@@ -29,7 +29,8 @@ spec:
         backend:
           service:
             name: {{ default $serviceDefaultName $value.serviceName }}
-            port: {{ default 80 $value.servicePort }}
+            port:
+              number: {{ default 80 $value.servicePort }}
 
 {{- end }}
 {{- end }}
@@ -43,7 +44,8 @@ spec:
         backend:
           service:
             name: {{ default $serviceDefaultName $value.serviceName }}
-            port: {{ default 80 $value.servicePort }}
+            port:
+              number: {{ default 80 $value.servicePort }}
 
     {{- end }}
   {{- end }}

--- a/charts/app/templates/services.yaml
+++ b/charts/app/templates/services.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.services.enabled -}}
+  {{- $serviceDefaultName :=  printf "%s-%s" (include "name" .) "sv" -}}
+  {{- range $serviceName, $serviceConfig := .Values.services.spec }}
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    namespace: {{ .Release.Namespace }}
+    name: {{ default $serviceDefaultName $serviceName }}
+    labels:
+      app: {{ template "name" . }}
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      release: "{{ .Release.Name }}"
+  spec:
+    ports:
+  {{- range $key, $value := $serviceConfig.ports }}
+    - port: {{ default 80 $value.externalPort }}
+      targetPort: {{ $value.internalPort }}
+      protocol: {{ $value.protocol }}
+      name: {{ $key }}
+  {{- end }}
+  selector:
+    app: {{ template "name" . }}
+    release: "{{ .Release.Name }}"
+  type: "ClusterIP"
+  {{- end -}}
+{{- end -}}

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -67,6 +67,16 @@ resources: {}
   # requests:
   #   memory: 400Mi
 
+services:
+  enabled: false
+  spec: {}
+    #  test-api-sv:
+    #    name: test-api
+    #    http:
+    #      protocol: TCP
+    #      externalPort: 80
+    #      internalPort: 8000
+
 ingress:
   enabled: false
   fqdn: ""
@@ -89,6 +99,8 @@ ingress:
     #     "/path":
     #       serviceName: "test-sv"
     #       servicePort: 8889
+
+
 
 job:
 #If true, create simple jobs, e.g. migration


### PR DESCRIPTION
**NOTE! We do not expect to merge these changes because we do not test them properly. This MR should show issues**

- Without `ingressClassName: nginx`, we do not route anything to the right service.
- Ingress template provide the functionality to link multiple services to separate path, but the template does not support creating multiple services, here I just show, how it can look like.