### PR TITLE
StorageClass name change

### DIFF
--- a/charts/nats/templates/store.yaml
+++ b/charts/nats/templates/store.yaml
@@ -2,7 +2,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: nats-ebs-sc-gp3
+  name: "{{ .Release.Name }}-nats-ebs-sc-gp3"
   labels:
     {{- include "nats.labels" . | nindent 4 }}
 provisioner: ebs.csi.aws.com


### PR DESCRIPTION
StorageClass is a cluster wide resource, and it met conflict when trying to deploy another release with this chart