### PR TITLE
feat: configurable ArgoCD Job hook + opt-in VSO rollout-restart on secret rotation (3.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [3.15.0] - 2026-07-04
+
+### Added
+- **Job** — optional `job.argocd` block (`hook`, `hookDeletePolicy`, `syncWave`) to control the ArgoCD lifecycle annotations of Jobs. Defaults preserve the historical behavior (`PreSync` / `BeforeHookCreation` / no sync-wave)
+- **Secrets (Vault)** — opt-in `secretsProvider.vault.rolloutRestart` (default `false`): each `VaultStaticSecret` lists the chart's own workloads (main Deployment + every worker Deployment) in `spec.rolloutRestartTargets`, so VSO rollout-restarts them when a synced secret changes
+- Unit tests: 2 new suites (job, vault-static-secret), 10 tests
+
+### Fixed
+- **ArgoCD PreSync deadlock on a fresh cluster** (via the new `job.argocd` knobs): with `secretsProvider.provider: vault` the Job's `envFrom` references a Secret created by a `VaultStaticSecret` — a Sync-phase resource. A `PreSync` hook waits for a Secret that only appears in the Sync phase, so the very first sync never completes. Setting `job.argocd.hook: Sync` + `syncWave: "-1"` runs the Job after the `VaultStaticSecret` while still gating the sync-wave `0` workloads
+- **Stale env after Vault secret rotation** (via `rolloutRestart`): secrets are injected through `envFrom` and read once at pod startup; without restart targets pods kept old values until the next deploy or a manual `kubectl rollout restart`
+
+### Notes
+- Fully backward compatible: with no new keys set, rendered output is byte-for-byte unchanged
+
 ## [3.14.0] - 2026-06-05
 
 ### Added

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -3,5 +3,5 @@ description: Deployment for base pinup app
 maintainers:
 - email: d7561985@gmail.com
   name: DevOps
-version: 3.14.0
+version: 3.15.0
 apiVersion: v2

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -117,10 +117,32 @@ secretsProvider:
     mount: "secret"           # KV engine mount
     type: "kv-v2"             # kv-v2 recommended
     refreshAfter: "1h"        # Sync interval
+    rolloutRestart: false     # Opt-in: restart workloads on secret change (below)
 
   aws:
     provider: "aws"           # For AWS SSM/Secrets Manager
 ```
+
+#### Rollout Restart on Secret Rotation
+
+Secrets are injected via `envFrom` and read **once at pod startup**: when a value
+rotates in Vault, VSO updates the Kubernetes Secret but running pods keep the old
+values until the next deploy or a manual `kubectl rollout restart`.
+
+Opt-in to automatic restarts with `rolloutRestart: true` — each `VaultStaticSecret`
+then lists the chart's own workloads (the main Deployment and every worker
+Deployment) as `spec.rolloutRestartTargets`, and VSO rollout-restarts them whenever
+the synced secret changes:
+
+```yaml
+secretsProvider:
+  provider: "vault"
+  vault:
+    rolloutRestart: true
+```
+
+> **Tip:** enable it on dev/stage for hands-free rotation; leave it `false` (default)
+> on prod if restarts must stay human-controlled.
 
 #### Supported Providers
 

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -881,6 +881,31 @@ Jobs automatically inherit:
 - Node selectors and tolerations
 - Image pull secrets
 
+### ArgoCD Hook Configuration
+
+By default Jobs run as an ArgoCD `PreSync` hook (unchanged historical behavior).
+The hook phase, delete policy and sync-wave are configurable:
+
+```yaml
+job:
+  enabled: true
+  argocd:
+    hook: Sync            # default: PreSync
+    syncWave: "-1"        # default: "" (annotation not rendered)
+    # hookDeletePolicy: BeforeHookCreation   (default)
+  spec:
+    migrate:
+      command: ["./migrate"]
+```
+
+> **When to change this.** With `secretsProvider.provider: vault` the Job's
+> `envFrom` references a Secret created by a `VaultStaticSecret` — a **Sync-phase**
+> resource (sync-wave `-2`). A `PreSync` hook waits for a Secret that only appears
+> in the Sync phase, which deadlocks the very first sync on a fresh cluster.
+> Set `hook: Sync` + `syncWave: "-1"` so the Job runs after the VaultStaticSecret
+> but still gates the sync-wave `0` workloads (sync-waves order hooks and regular
+> resources together within the Sync phase).
+
 ---
 
 ## CronJob

--- a/charts/app/templates/job.yaml
+++ b/charts/app/templates/job.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.job.enabled -}}
   {{- $appname := printf "%s" (include "name" .) -}}
   {{- $jobName :=  printf "%s-%s" (include "name" .) "job" -}}
+  {{- /* ArgoCD lifecycle knobs; defaults preserve the historical PreSync behavior */ -}}
+  {{- $argocd := .Values.job.argocd | default dict -}}
   {{- range $key, $value := .Values.job.spec }}
 ---
 apiVersion: batch/v1
@@ -8,8 +10,11 @@ kind: Job
 metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
-    argocd.argoproj.io/hook: PreSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/hook: {{ $argocd.hook | default "PreSync" }}
+    argocd.argoproj.io/hook-delete-policy: {{ $argocd.hookDeletePolicy | default "BeforeHookCreation" }}
+    {{- with $argocd.syncWave }}
+    argocd.argoproj.io/sync-wave: {{ . | quote }}
+    {{- end }}
   labels:
     helm.sh/chart: "{{$.Chart.Name}}-{{$.Chart.Version}}"
     job: "{{ $jobName }}"

--- a/charts/app/templates/secrets/vault-static-secret.yaml
+++ b/charts/app/templates/secrets/vault-static-secret.yaml
@@ -46,6 +46,19 @@ spec:
   path: {{ $path }}
   refreshAfter: {{ $vaultConfig.refreshAfter | default "1h" }}
   vaultAuthRef: {{ $vaultConfig.authRef | default "vault-auth" }}
+  {{- /* Opt-in: restart the chart's own workloads when the synced secret changes
+         (secrets are consumed via envFrom — read once at pod startup) */ -}}
+  {{- if $vaultConfig.rolloutRestart }}
+  rolloutRestartTargets:
+    - kind: Deployment
+      name: {{ $appname }}
+    {{- if $root.Values.worker.enabled }}
+    {{- range $workerName, $_ := $root.Values.worker.spec }}
+    - kind: Deployment
+      name: {{ $appname }}-{{ $workerName }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
   destination:
     name: {{ $appname }}-vault-{{ $pathIndex }}
     create: true

--- a/charts/app/tests/job_test.yaml
+++ b/charts/app/tests/job_test.yaml
@@ -1,0 +1,86 @@
+suite: Job
+templates:
+  - job.yaml
+values:
+  - ../values.yaml
+
+tests:
+  - it: should not render when job is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create one Job per spec entry
+    set:
+      appName: myapp
+      job:
+        enabled: true
+        spec:
+          migrate:
+            command: ["./migrate"]
+          seed:
+            command: ["./seed"]
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Job
+
+  - it: should keep historical ArgoCD annotations by default (PreSync, no sync-wave)
+    set:
+      appName: myapp
+      job:
+        enabled: true
+        spec:
+          migrate:
+            command: ["./migrate"]
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+          value: BeforeHookCreation
+      - notExists:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+
+  - it: should render configurable hook, delete policy and sync-wave
+    set:
+      appName: myapp
+      job:
+        enabled: true
+        argocd:
+          hook: Sync
+          hookDeletePolicy: HookSucceeded
+          syncWave: "-1"
+        spec:
+          migrate:
+            command: ["./migrate"]
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: Sync
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+          value: HookSucceeded
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "-1"
+
+  - it: should fall back to defaults when argocd block is partially set
+    set:
+      appName: myapp
+      job:
+        enabled: true
+        argocd:
+          syncWave: "-1"
+        spec:
+          migrate:
+            command: ["./migrate"]
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "-1"

--- a/charts/app/tests/vault_static_secret_test.yaml
+++ b/charts/app/tests/vault_static_secret_test.yaml
@@ -1,0 +1,84 @@
+suite: VaultStaticSecret
+templates:
+  - secrets/vault-static-secret.yaml
+values:
+  - ../values.yaml
+
+tests:
+  - it: should not render when provider is none (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create one VaultStaticSecret per unique path
+    set:
+      appName: myapp
+      environment: dev
+      secretsProvider:
+        provider: vault
+      secrets:
+        DB_PASSWORD: "brand/myapp/{env}/config"
+        API_KEY: "brand/myapp/{env}/config"
+        SHARED_TOKEN: "brand/shared/{env}/config"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: VaultStaticSecret
+
+  - it: should not render rolloutRestartTargets by default
+    set:
+      appName: myapp
+      environment: dev
+      secretsProvider:
+        provider: vault
+      secrets:
+        DB_PASSWORD: "brand/myapp/{env}/config"
+    asserts:
+      - notExists:
+          path: spec.rolloutRestartTargets
+
+  - it: should render the main Deployment as restart target when rolloutRestart is enabled
+    set:
+      appName: myapp
+      environment: dev
+      secretsProvider:
+        provider: vault
+        vault:
+          rolloutRestart: true
+      secrets:
+        DB_PASSWORD: "brand/myapp/{env}/config"
+    asserts:
+      - equal:
+          path: spec.rolloutRestartTargets
+          value:
+            - kind: Deployment
+              name: myapp
+
+  - it: should include worker Deployments as restart targets
+    set:
+      appName: myapp
+      environment: dev
+      secretsProvider:
+        provider: vault
+        vault:
+          rolloutRestart: true
+      secrets:
+        DB_PASSWORD: "brand/myapp/{env}/config"
+      worker:
+        enabled: true
+        spec:
+          default:
+            command: ["./worker"]
+          priority:
+            command: ["./worker"]
+    asserts:
+      - equal:
+          path: spec.rolloutRestartTargets
+          value:
+            - kind: Deployment
+              name: myapp
+            - kind: Deployment
+              name: myapp-default
+            - kind: Deployment
+              name: myapp-priority

--- a/charts/app/values.example.yaml
+++ b/charts/app/values.example.yaml
@@ -263,6 +263,12 @@ worker:
 # -----------------------------------------------------------------------------
 job:
   enabled: true
+  # Optional ArgoCD lifecycle override (defaults: PreSync / BeforeHookCreation /
+  # no sync-wave). Use Sync + "-1" when the job consumes Vault-provided secrets —
+  # see the "ArgoCD Hook Configuration" section in README.md.
+  argocd:
+    hook: Sync
+    syncWave: "-1"
   spec:
     migrate-db:
       backoffLimit: 3

--- a/charts/app/values.example.yaml
+++ b/charts/app/values.example.yaml
@@ -96,6 +96,7 @@ secretsProvider:
     mount: "secret"
     type: "kv-v2"
     refreshAfter: "1h"
+    rolloutRestart: true  # opt-in: VSO restarts the Deployment/workers on secret change
 
 # -----------------------------------------------------------------------------
 # Image Pull Secrets

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -397,6 +397,13 @@ secretsProvider:
     mount: "secret"           # KV secrets engine mount
     type: "kv-v2"             # Engine type: kv-v2 or kv-v1
     refreshAfter: "1h"        # How often to sync secrets
+    # Opt-in: when a synced secret changes, VSO rollout-restarts the chart's
+    # workloads (the main Deployment and every worker Deployment) so pods pick
+    # up new values — secrets are injected via envFrom and read at startup.
+    # false (default) = current behavior: pods keep old values until the next
+    # deploy or a manual rollout restart. Recommended true on dev/stage; keep
+    # false on prod if restarts must stay human-controlled.
+    rolloutRestart: false
 
   # AWS Secrets Manager settings
   aws:

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -239,6 +239,18 @@ cache:
 job:
 # If true, create simple jobs, e.g. migration
   enabled: false
+  # ArgoCD lifecycle of the Jobs. Defaults preserve the historical behavior
+  # (PreSync hook, BeforeHookCreation delete policy, no sync-wave).
+  # NOTE: with secretsProvider.provider "vault" the Job's envFrom references a
+  # Secret created by a VaultStaticSecret — a Sync-phase resource (sync-wave "-2").
+  # A PreSync hook then waits for a Secret that only appears in the Sync phase,
+  # which deadlocks the very first sync on a fresh cluster. For that case set
+  # hook: "Sync" and syncWave: "-1" (runs after the VaultStaticSecret, still
+  # before the sync-wave "0" workloads).
+  argocd:
+    hook: PreSync                         # PreSync | Sync | PostSync | Skip
+    hookDeletePolicy: BeforeHookCreation  # BeforeHookCreation | HookSucceeded | HookFailed
+    syncWave: ""                          # e.g. "-1"; empty = annotation not rendered
   spec: {}
   # printenv:
   #   backoffLimit: 1


### PR DESCRIPTION
Two optional, fully backward-compatible knobs, both hit in production GitOps use (ArgoCD + Vault Secrets Operator). With no new keys set, rendered output is byte-for-byte unchanged (verified by diffing `helm template` output before/after).

## 1. `job.argocd` — configurable ArgoCD lifecycle annotations (fixes a fresh-cluster deadlock)

`templates/job.yaml` hardcodes `argocd.argoproj.io/hook: PreSync`, while the `VaultStaticSecret` is a **Sync-phase** resource (`sync-wave: "-2"`). Sync-waves only order resources *within* a phase and the whole PreSync phase runs *before* Sync — so on a **fresh cluster** a Job with `secretsProvider.provider: vault` waits (`CreateContainerConfigError`) for a Secret that is never applied, and the very first sync deadlocks. On long-lived clusters this stays invisible because the Secret already exists from earlier syncs.

```yaml
job:
  argocd:
    hook: Sync            # default: PreSync (historical behavior)
    syncWave: "-1"        # default: "" (annotation not rendered)
    # hookDeletePolicy: BeforeHookCreation (default)
```

`hook: Sync` + `syncWave: "-1"` runs the Job after the VaultStaticSecret while still gating the sync-wave `0` workloads (within the Sync phase, waves order hooks and regular resources together).

## 2. `secretsProvider.vault.rolloutRestart` — opt-in restart on secret rotation

Secrets are consumed via `envFrom` and read once at pod startup: when a value rotates in Vault, VSO updates the K8s Secret but running pods keep stale env until the next deploy or a manual `kubectl rollout restart` — rotation latency is effectively unbounded.

```yaml
secretsProvider:
  vault:
    rolloutRestart: true   # default: false (current behavior)
```

When enabled, each `VaultStaticSecret` lists the chart's own workloads (main Deployment + every worker Deployment) in `spec.rolloutRestartTargets`, so VSO rollout-restarts them whenever a synced secret changes. Typical usage: `true` on dev/stage, `false` on prod where restarts stay human-controlled.

## Included

- 2 new helm-unittest suites (`job_test.yaml`, `vault_static_secret_test.yaml`), 10 tests — full suite now 11 suites / 58 tests, all green
- README sections (Job → ArgoCD Hook Configuration; Secrets → Rollout Restart on Secret Rotation), `values.yaml` comments, `values.example.yaml`
- `CHANGELOG.md` + chart version 3.15.0 (MINOR: backward-compatible additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)