### PR TITLE
fix(deployment): render resources/ports on extension sidecars + fix volumeMounts nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [3.16.0] - 2026-07-22
+
+### Added
+- **Extensions** — extension (sidecar) containers in the main `Deployment` now render `ports`. Set `extensions.<name>.ports` (a standard container `ports` list) and it appears on the sidecar
+
+### Fixed
+- **Extensions** — `resources` declared on an extension were silently dropped by `deployment.yaml` (rendered only for `worker` pods), so every sidecar ran unbounded even though `extensions.<name>.resources` is documented and honored elsewhere. The Deployment's extension container now renders `resources`, matching `worker.yaml`
+- **Extensions** — an extension's `volumeMounts` (from `configfiles` / `sharedVolumes`) were nested inside `{{ if $spec.readinessProbe }}` because the readiness-probe block was missing a closing `{{ end }}`. A sidecar with `configfiles` but no probe therefore silently kept the image's default config (nothing mounted). The block is now closed correctly, so mounts render regardless of whether a probe is set
+
+### Notes
+- Backward compatible where the chart already produced correct output. Rendered output changes only in the cases these fixes target: extensions that declared `resources` (now applied), `ports` (now applied), or `configfiles` / `sharedVolumes` without a probe (now mounted)
+
 ## [3.15.0] - 2026-07-04
 
 ### Added

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -3,5 +3,5 @@ description: Deployment for base pinup app
 maintainers:
 - email: d7561985@gmail.com
   name: DevOps
-version: 3.15.0
+version: 3.16.0
 apiVersion: v2

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -1355,6 +1355,7 @@ extensions:
 
 Extensions support most container features:
 - Custom images, commands, and arguments
+- Container ports
 - Resource limits and requests
 - Environment variables
 - Health checks (liveness/readiness probes)

--- a/charts/app/templates/deployment.yaml
+++ b/charts/app/templates/deployment.yaml
@@ -391,6 +391,7 @@ spec:
           successThreshold: {{ .successThreshold | default 1 }}
           timeoutSeconds: {{ .timeoutSeconds | default 5 }}
         {{- end }}
+        {{- end }}
         {{- if or $spec.configfiles $.Values.sharedVolumes }}
         volumeMounts:
           {{- if $spec.configfiles }}
@@ -418,6 +419,13 @@ spec:
           {{- end }}
           {{- end }}
         {{- end }}
+        {{- if $spec.resources }}
+        resources:
+          {{- toYaml $spec.resources | nindent 10 }}
+        {{- end }}
+        {{- if $spec.ports }}
+        ports:
+          {{- toYaml $spec.ports | nindent 10 }}
         {{- end }}
     {{- end }}
     {{- /* Image Pull Secrets - New universal approach */ -}}

--- a/charts/app/tests/deployment_test.yaml
+++ b/charts/app/tests/deployment_test.yaml
@@ -177,3 +177,78 @@ tests:
     asserts:
       - isNotNull:
           path: spec.template.metadata.annotations["checksum/secrets"]
+
+  - it: should render resources on an extension sidecar
+    set:
+      appName: myapp
+      extensions:
+        sidecar:
+          image:
+            repository: nginx
+            tag: "1.27-alpine"
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: myapp-sidecar
+      - equal:
+          path: spec.template.spec.containers[1].resources.limits.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[1].resources.requests.memory
+          value: 32Mi
+
+  - it: should render ports on an extension sidecar
+    set:
+      appName: myapp
+      extensions:
+        sidecar:
+          image:
+            repository: nginx
+            tag: "1.27-alpine"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].ports[0].containerPort
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[1].ports[0].name
+          value: http
+
+  # Regression: an extension's volumeMounts must render even when the extension
+  # has no probe. Previously volumeMounts were nested inside `if readinessProbe`,
+  # so a sidecar with configfiles but no probe silently got no config mounted.
+  - it: should mount extension configfiles without a readinessProbe
+    set:
+      appName: myapp
+      extensions:
+        sidecar:
+          image:
+            repository: nginx
+            tag: "1.27-alpine"
+          configfiles:
+            mountPath: /etc/nginx/conf.d
+            files:
+              - key: default.conf
+                path: default.conf
+                mountPath: /etc/nginx/conf.d/default.conf
+            data:
+              default.conf: |
+                server { listen 8080; }
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: myapp-sidecar-config
+            mountPath: /etc/nginx/conf.d/default.conf
+            subPath: default.conf
+            readOnly: true

--- a/charts/app/values.example.yaml
+++ b/charts/app/values.example.yaml
@@ -233,6 +233,10 @@ extensions:
     image:
       repository: "envoyproxy/envoy"
       tag: "v1.28.0"
+    ports:
+      - name: http
+        containerPort: 10000
+        protocol: TCP
     resources:
       requests:
         memory: "64Mi"

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -523,6 +523,10 @@ extensions: {}
   #     repository: "example.org"
   #     name: "sidecar"
   #     tag: "1.0.0"
+  #   ports:
+  #     - name: http
+  #       containerPort: 8080
+  #       protocol: TCP
   #   command:
   #     - start
   #   args:


### PR DESCRIPTION
## Summary

Extension (sidecar) containers in the main `Deployment` silently dropped several fields that the chart accepts in `values`:

1. **`resources` ignored** — rendered only for `worker` pods, never for the Deployment's sidecars, so every sidecar ran unbounded. `extensions.<name>.resources` is documented (README "Extension Features" → "Resource limits and requests", and the `values.example.yaml` sidecar sets it), so this is an accepted-but-dropped value.
2. **`volumeMounts` not mounted without a probe** — an extension's `volumeMounts` (from `configfiles` / `sharedVolumes`) were nested inside `{{ if $spec.readinessProbe }}` because the readiness-probe block was missing a closing `{{ end }}`. A sidecar with `configfiles` but no probe therefore kept the image's default config (nothing mounted).
3. **`ports` ignored** — `extensions.<name>.ports` was accepted in values but never rendered on the sidecar container.

## Root cause

All three live in the extensions loop of `charts/app/templates/deployment.yaml`:

- The `readinessProbe` block opened `if` + `with` but closed only once, so the following `volumeMounts` block (and its own `if`) sat inside `if $spec.readinessProbe`. `worker.yaml`'s equivalent is balanced; `deployment.yaml` was not.
- The loop never emitted `resources` or `ports` for the sidecar (only the main container / workers did).

## Changes

- `charts/app/templates/deployment.yaml` — add the missing `{{ end }}` so `volumeMounts` renders regardless of probes; render `resources` and `ports` for extension containers (same pattern `worker.yaml` already uses for `resources`).
- `charts/app/tests/deployment_test.yaml` — 3 helm-unittest cases: resources render, ports render, and a regression for mounting `configfiles` without a probe.
- `charts/app/values.yaml`, `charts/app/values.example.yaml`, `charts/app/README.md` — document extension `ports`.
- `charts/app/Chart.yaml` — `3.15.0` → `3.16.0`; `CHANGELOG.md` updated.

## Testing

- `helm unittest ./charts/app` → 11 suites, 61 tests pass (58 existing + 3 new).
- `helm lint ./charts/app` → clean.
- `helm template` with a sidecar that sets `resources`/`ports`/`configfiles` and no probe now renders all three; previously only a sidecar with a probe got its `volumeMounts`, and `resources`/`ports` never appeared.

## Backward compatibility

Output is unchanged for extensions that set none of `resources`/`ports` and either have a probe or declare no mounts. It changes only where the chart previously discarded a declared value: sidecars with `resources` (now applied), `ports` (now applied), or `configfiles` / `sharedVolumes` without a probe (now mounted).
